### PR TITLE
Add basic Flask homepage fetching vnstock data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# cong_rep
+# VNStock Data Explorer
+
+A minimal Flask web app that connects to the **vnstock** library and displays sample stock data on the homepage.
+
+## Setup
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Start the development server:
+
+   ```bash
+   python app.py
+   ```
+
+The home page fetches data for ticker `ACB` using the `vnstock` package. Errors are displayed on the page if the data source is unavailable.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,29 @@
+from flask import Flask, render_template
+
+try:
+    from vnstock import Vnstock
+    vn = Vnstock()
+except Exception as e:
+    vn = None
+    vn_import_error = e
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    """Homepage that fetches stock data using vnstock library."""
+    error = None
+    data = None
+    if vn is None:
+        error = f"Could not import vnstock: {vn_import_error}"
+    else:
+        try:
+            # Fetch sample data for ticker ACB using source VCI
+            df = vn.stock(symbol="ACB", source="VCI").price_board()
+            data = df.to_dict(orient="records")
+        except Exception as e:
+            error = str(e)
+    return render_template('index.html', data=data, error=error)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+vnstock

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>VNStock Home</title>
+  <style>
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ccc; padding: 8px; }
+  </style>
+</head>
+<body>
+  <h1>VNStock Data Explorer</h1>
+  {% if error %}
+    <p style="color:red;">{{ error }}</p>
+  {% elif data %}
+    <table>
+      <tr>
+        {% for key in data[0].keys() %}
+          <th>{{ key }}</th>
+        {% endfor %}
+      </tr>
+      {% for row in data %}
+        <tr>
+          {% for val in row.values() %}
+            <td>{{ val }}</td>
+          {% endfor %}
+        </tr>
+      {% endfor %}
+    </table>
+  {% else %}
+    <p>No data available.</p>
+  {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up a minimal Flask app that uses the vnstock library to load sample data for ticker `ACB` and render it on the homepage.
- add an HTML template to show either the data table or error messages.
- document setup instructions and dependencies.

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement flask)*
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68a4a8ab1bb483338d6a38683d3cbe4f