### PR TITLE
Fix vnstock quote attribute call

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# cong_rep
+# VNStock Data Explorer
+
+A minimal Flask web app that connects to the **vnstock** library and displays sample stock data on the homepage.
+
+## Setup
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Start the development server:
+
+   ```bash
+   python app.py
+   ```
+
+The home page fetches data for ticker `ACB` using the `vnstock` package. Errors are displayed on the page if the data source is unavailable.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,30 @@
+from flask import Flask, render_template
+
+try:
+    from vnstock import Vnstock
+    vn = Vnstock()
+except Exception as e:
+    vn = None
+    vn_import_error = e
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    """Homepage that fetches stock data using vnstock library."""
+    error = None
+    data = None
+    if vn is None:
+        error = f"Could not import vnstock: {vn_import_error}"
+    else:
+        try:
+            # Fetch sample quote data for ticker ACB using source VCI
+            data = vn.stock(symbol="ACB", source="VCI").quote.to_dict(
+                orient="records"
+            )
+        except Exception as e:
+            error = str(e)
+    return render_template('index.html', data=data, error=error)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+vnstock

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>VNStock Home</title>
+  <style>
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ccc; padding: 8px; }
+  </style>
+</head>
+<body>
+  <h1>VNStock Data Explorer</h1>
+  {% if error %}
+    <p style="color:red;">{{ error }}</p>
+  {% elif data %}
+    <table>
+      <tr>
+        {% for key in data[0].keys() %}
+          <th>{{ key }}</th>
+        {% endfor %}
+      </tr>
+      {% for row in data %}
+        <tr>
+          {% for val in row.values() %}
+            <td>{{ val }}</td>
+          {% endfor %}
+        </tr>
+      {% endfor %}
+    </table>
+  {% else %}
+    <p>No data available.</p>
+  {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Use `quote` attribute instead of calling it as a function when fetching ACB sample data

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement flask)*
- `python -m py_compile app.py`
- `python app.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68a4a8ab1bb483338d6a38683d3cbe4f